### PR TITLE
update for run two service with one docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,15 +8,14 @@ RUN apt update && apt-get install -y --no-install-recommends \
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-ENTRYPOINT [ "python" ]
 
-FROM base AS event-aggregator
-
+# aggregator service
 COPY event-aggregator/event_aggregator.py .
 COPY event-aggregator/kafka_consumer_sensor_event.py .
 COPY event-aggregator/kafka_producer_opencti_event.py .
 COPY event-aggregator/sensor_event_pb2.py .
-
-FROM base AS event-parser
-
+# parser service
 COPY event-parser/event_parser.py ./event_parser.py
+
+COPY start.sh ./start.sh
+CMD ["sh", "start.sh"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,14 +1,15 @@
 services:
   opencti-connector-aggregator:
-    image: ghcr.io/mata-elang-stable/opencti-connector-aggregator:latest
+    image: ghcr.io/mata-elang-stable/opencti-connector:latest
     build:
       context: .
       target: event-aggregator
     restart: unless-stoped
     container_name: opencti-connector-aggregator
+    environment:
+      - SERVICE=event-aggregator
     env_file:
       - ./event-aggregator/.env
-    command: ["-u", "kafka_consumer_sensor_event.py"]
     deploy:
       mode: replicated
       replicas: 1
@@ -21,15 +22,16 @@ services:
           memory: 256M
 
   opencti-connector-parser:
-    image: ghcr.io/mata-elang-stable/opencti-connector-parser:latest
+    image: ghcr.io/mata-elang-stable/opencti-connector:latest
     build:
       context: .
       target: event-parser
     container_name: opencti-connector-parser
+    environment:
+      - SERVICE=event-parser
     env_file:
       - ./event-parser/.env
     restart: unless-stoped
-    command: ["-u", "event_parser.py"]
     deploy:
       mode: replicated
       replicas: 1

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+echo "Starting service: $SERVICE"
+
+if [ "$SERVICE" = "event-aggregator" ]; then
+    echo "Running Event Aggregator..."
+    exec python -u kafka_consumer_sensor_event.py
+elif [ "$SERVICE" = "event-parser" ]; then
+    echo "Running Event Parser..."
+    exec python -u event_parser.py
+else
+    echo "Error: Unknown or missing SERVICE environment variable!"
+    exit 1
+fi


### PR DESCRIPTION
This pull request includes several changes to the Docker setup and configuration for the `opencti-connector` services. The most important changes include updating the Dockerfile to streamline service definitions, modifying the `docker-compose.yaml` file to use a single image for both services, and adding a startup script to handle service execution based on environment variables.

### Dockerfile and Service Configuration:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L11-R21): Consolidated the service definitions for `event-aggregator` and `event-parser` by removing redundant `FROM` statements and adding a startup script (`start.sh`).

### Docker Compose Configuration:

* [`docker-compose.yaml`](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L3-L11): Updated the image references for `opencti-connector-aggregator` and `opencti-connector-parser` to use a single image (`ghcr.io/mata-elang-stable/opencti-connector:latest`) and added environment variables to specify the service type. [[1]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L3-L11) [[2]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L24-L32)

### Startup Script:

* [`start.sh`](diffhunk://#diff-65a5db1ae8f8e01ebdbbfafcf4e24618ad7cffe036bba92dce1390383e5c73e5R1-R14): Added a new script to handle the startup of either the `event-aggregator` or `event-parser` service based on the `SERVICE` environment variable. This script ensures the correct service is executed and provides error handling for unknown or missing service types.