### PR TITLE
update id job

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -54,7 +54,7 @@ jobs:
         uses: crazy-max/ghaction-github-runtime@v3
 
       - name: Build for Service opencti-connector-aggregator
-        id: push
+        id: push-aggregator
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -69,7 +69,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build for Service opencti-connector-parser
-        id: push
+        id: push-parser
         uses: docker/build-push-action@v6
         with:
           context: .


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/docker-build.yml` file to improve clarity and precision in the build steps for different services. The most important changes include updating the `id` fields for specific build actions.

Workflow improvements:

* [`.github/workflows/docker-build.yml`](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L57-R57): Changed the `id` from `push` to `push-aggregator` for the build action of the `opencti-connector-aggregator` service to provide a more specific identifier.
* [`.github/workflows/docker-build.yml`](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L72-R72): Changed the `id` from `push` to `push-parser` for the build action of the `opencti-connector-parser` service to provide a more specific identifier.