### PR TITLE
add job artifact attestation

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -83,10 +83,18 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Generate artifact attestation
+      - name: Generate artifact attestation for service aggregator
         if: github.event_name != 'pull_request'
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}-aggregator
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+      - name: Generate artifact attestation for service parser
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}-parser
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/docker-build.yml` file to enhance the artifact attestation process for different services. The most important changes include generating separate attestations for the service aggregator and the service parser.

Enhancements to artifact attestation:

* [`.github/workflows/docker-build.yml`](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L86-R98): Modified the job to generate artifact attestation specifically for the service aggregator by updating the `subject-name` and adding `subject-digest` and `push-to-registry` fields.
* [`.github/workflows/docker-build.yml`](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L86-R98): Added a new job to generate artifact attestation for the service parser with the appropriate `subject-name`, `subject-digest`, and `push-to-registry` fields.