### PR TITLE
update attestation subject digest for each service

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -88,7 +88,7 @@ jobs:
         uses: actions/attest-build-provenance@v2
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}-aggregator
-          subject-digest: ${{ steps.push.outputs.digest }}
+          subject-digest: ${{ steps.push-aggregator.outputs.digest }}
           push-to-registry: true
 
       - name: Generate artifact attestation for service parser
@@ -96,5 +96,5 @@ jobs:
         uses: actions/attest-build-provenance@v2
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}-parser
-          subject-digest: ${{ steps.push.outputs.digest }}
+          subject-digest: ${{ steps.push-parser.outputs.digest }}
           push-to-registry: true


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/docker-build.yml` file to correct the subject-digest references for different services.

Changes in `jobs:` in `.github/workflows/docker-build.yml`:

* Updated the `subject-digest` for the `aggregator` service to use `${{ steps.push-aggregator.outputs.digest }}` instead of `${{ steps.push.outputs.digest }}`.
* Updated the `subject-digest` for the `parser` service to use `${{ steps.push-parser.outputs.digest }}` instead of `${{ steps.push.outputs.digest }}`.