### PR TITLE
add job metada and update some job

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -12,7 +12,8 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME_AGGREGATOR: ${{ github.repository }}-aggregator
+  IMAGE_NAME_PARSER: ${{ github.repository }}-parser
   BUILDER_NAME: mybuilder
   BUILD_PLATFORMS_TARGET: linux/amd64
 
@@ -38,12 +39,23 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
+      - name: Extract metadata (tags, labels) for Docker for service aggregator
+        id: meta-aggregator
         if: github.event_name != 'pull_request'
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_AGGREGATOR }}
+          flavor: |
+            latest=auto
+            prefix=
+            suffix=
+
+      - name: Extract metadata (tags, labels) for Docker for service parser
+        id: meta-parser
+        if: github.event_name != 'pull_request'
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_PARSER }}
           flavor: |
             latest=auto
             prefix=
@@ -63,8 +75,8 @@ jobs:
           platforms: ${{ env.BUILD_PLATFORMS_TARGET }}
           push: ${{ github.event_name != 'pull_request' }}
           builder: ${{ env.BUILDER_NAME }}
-          tags: ${{ steps.meta.outputs.tags }}-aggregator
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta-aggregator.outputs.tags }}
+          labels: ${{ steps.meta-aggregator.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -78,8 +90,8 @@ jobs:
           platforms: ${{ env.BUILD_PLATFORMS_TARGET }}
           push: ${{ github.event_name != 'pull_request' }}
           builder: ${{ env.BUILDER_NAME }}
-          tags: ${{ steps.meta.outputs.tags }}-parser
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta-parser.outputs.tags }}
+          labels: ${{ steps.meta-parser.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
This pull request involves changes to the `.github/workflows/docker-build.yml` file to support building and tagging Docker images for two separate services: an aggregator and a parser. The most important changes include updating environment variables, modifying job steps to handle metadata extraction, and adjusting build tags and labels for each service.

Changes to environment variables:

* [`.github/workflows/docker-build.yml`](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L15-R16): Updated `IMAGE_NAME` to `IMAGE_NAME_AGGREGATOR` and `IMAGE_NAME_PARSER` to differentiate between the aggregator and parser services.

Modifications to job steps:

* [`.github/workflows/docker-build.yml`](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L41-R58): Added separate steps for extracting metadata for the aggregator and parser services, using `meta-aggregator` and `meta-parser` IDs respectively.

Adjustments to build tags and labels:

* [`.github/workflows/docker-build.yml`](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L66-R79): Updated the build steps to use the appropriate tags and labels for the aggregator service based on the `meta-aggregator` outputs.
* [`.github/workflows/docker-build.yml`](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L81-R94): Updated the build steps to use the appropriate tags and labels for the parser service based on the `meta-parser` outputs.