### PR TITLE
fixing image name variable at job attestation

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -99,7 +99,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}-aggregator
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_AGGREGATOR}}
           subject-digest: ${{ steps.push-aggregator.outputs.digest }}
           push-to-registry: true
 
@@ -107,6 +107,6 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}-parser
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_PARSER}}
           subject-digest: ${{ steps.push-parser.outputs.digest }}
           push-to-registry: true


### PR DESCRIPTION
This pull request involves changes to the `.github/workflows/docker-build.yml` file to support building and tagging Docker images for two separate services: an aggregator and a parser. The most important changes include updating environment variables, modifying job steps to handle metadata extraction, and adjusting build tags and labels for each service.

Changes to environment variables:

* [`.github/workflows/docker-build.yml`](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L15-R16): Updated `IMAGE_NAME` to `IMAGE_NAME_AGGREGATOR` and `IMAGE_NAME_PARSER` to differentiate between the aggregator and parser services.

Modifications to job steps:

* [`.github/workflows/docker-build.yml`](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L41-R58): Added separate steps for extracting metadata for the aggregator and parser services, using `meta-aggregator` and `meta-parser` IDs respectively.

Adjustments to build tags and labels:

* [`.github/workflows/docker-build.yml`](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L66-R79): Updated the build steps to use the appropriate tags and labels for the aggregator service based on the `meta-aggregator` outputs.
* [`.github/workflows/docker-build.yml`](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L81-R94): Updated the build steps to use the appropriate tags and labels for the parser service based on the `meta-parser` outputs.