### PR TITLE
fix: correct target key in Docker build workflow and add CMD for event scripts

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -71,7 +71,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          targets: event-aggregator
+          target: event-aggregator
           platforms: ${{ env.BUILD_PLATFORMS_TARGET }}
           push: ${{ github.event_name != 'pull_request' }}
           builder: ${{ env.BUILDER_NAME }}
@@ -86,7 +86,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          targets: event-parser
+          target: event-parser
           platforms: ${{ env.BUILD_PLATFORMS_TARGET }}
           push: ${{ github.event_name != 'pull_request' }}
           builder: ${{ env.BUILDER_NAME }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,15 +8,24 @@ RUN apt update && apt-get install -y --no-install-recommends \
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
+
+WORKDIR /app
+
 ENTRYPOINT [ "python" ]
 
 FROM base AS event-aggregator
+
+WORKDIR /app
 
 COPY event-aggregator/event_aggregator.py .
 COPY event-aggregator/kafka_consumer_sensor_event.py .
 COPY event-aggregator/kafka_producer_opencti_event.py .
 COPY event-aggregator/sensor_event_pb2.py .
 
+CMD ["-u", "kafka_consumer_sensor_event.py"]
+
 FROM base AS event-parser
 
 COPY event-parser/event_parser.py ./event_parser.py
+
+CMD ["-u", "event_parser.py"]


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/docker-build.yml` file and the `Dockerfile` to fix syntax issues and improve the Docker build process. The most important changes include correcting the syntax for specifying build targets and adding working directories and command instructions for the Docker images.

Fixes to Docker build workflow:

* [`.github/workflows/docker-build.yml`](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L74-R74): Corrected the key from `targets` to `target` for the `event-aggregator` and `event-parser` build steps. [[1]](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L74-R74) [[2]](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L89-R89)

Improvements to Dockerfile:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R11-R31): Added `WORKDIR /app` to set the working directory for `event-aggregator` and `event-parser` stages.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R11-R31): Added `CMD` instructions to specify the default commands for running `event-aggregator` and `event-parser` containers.