### PR TITLE
fix: update Docker build workflow to set latest flavor to true and adjust Dockerfile structure

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_AGGREGATOR }}
           flavor: |
-            latest=auto
+            latest=true
             prefix=
             suffix=
 
@@ -57,7 +57,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_PARSER }}
           flavor: |
-            latest=auto
+            latest=true
             prefix=
             suffix=
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.12-slim AS base
 
+WORKDIR /app
+
 RUN apt update && apt-get install -y --no-install-recommends \
     gcc \
     librdkafka-dev \
@@ -7,15 +9,12 @@ RUN apt update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
 
-WORKDIR /app
+RUN pip install --no-cache-dir -r requirements.txt
 
 ENTRYPOINT [ "python" ]
 
 FROM base AS event-aggregator
-
-WORKDIR /app
 
 COPY event-aggregator/event_aggregator.py .
 COPY event-aggregator/kafka_consumer_sensor_event.py .


### PR DESCRIPTION
This pull request includes changes to the Docker build workflow and the Dockerfile to improve the build process and organization. The most important changes include updating the Docker build workflow to use the latest image version and reorganizing the Dockerfile for better readability and efficiency.

Changes to Docker build workflow:

* [`.github/workflows/docker-build.yml`](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L49-R49): Updated the `flavor` parameter to set `latest=true` instead of `latest=auto` for both the aggregator and parser images. [[1]](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L49-R49) [[2]](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L60-R60)

Changes to Dockerfile:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R3-L19): Moved the `WORKDIR /app` command to the base stage and reordered the `RUN pip install` command for better readability and efficiency.